### PR TITLE
Emsdk upgrade to latest version

### DIFF
--- a/.github/workflows/ubuntu-emscripten.yml
+++ b/.github/workflows/ubuntu-emscripten.yml
@@ -12,7 +12,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: mymindstorm/setup-emsdk@v9
+    - uses: mymindstorm/setup-emsdk@v11
+      with:
+          version: 3.1.8
     - name: build
       run: |
         emcmake cmake -E make_directory build

--- a/cmake/FindPCRE2.cmake
+++ b/cmake/FindPCRE2.cmake
@@ -35,6 +35,13 @@ if(SSPLIT_USE_INTERNAL_PCRE2)
   else()
     set(PCRE2_JIT_OPTION  "-DPCRE2_SUPPORT_JIT=ON")
   endif()
+
+  # CMAKE_CROSSCOMPILING_EMULATOR might contain semicolon (;) separated arguments. Preventing list
+  # expansion on the arguments of this variable before adding it to PCRE2_CONFIGURE_OPTIONS
+  # by replacing semicolon with $<SEMICOLON> as per:
+  # https://cmake.org/cmake/help/git-stage/manual/cmake-generator-expressions.7.html#genex:SEMICOLON
+  string(REPLACE ";" "$<SEMICOLON>" CMAKE_CROSSCOMPILING_EMULATOR_WITH_SEMICOLON "${CMAKE_CROSSCOMPILING_EMULATOR}")
+
   set(PCRE2_CONFIGURE_OPTIONS
     -DBUILD_SHARED_LIBS=OFF
     -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}
@@ -42,7 +49,7 @@ if(SSPLIT_USE_INTERNAL_PCRE2)
     -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
     ${PCRE2_JIT_OPTION}
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE} # Necessary for proper MacOS compilation
-    -DCMAKE_CROSSCOMPILING_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR} # Necessary for proper MacOS compilation
+    -DCMAKE_CROSSCOMPILING_EMULATOR=${CMAKE_CROSSCOMPILING_EMULATOR_WITH_SEMICOLON} # Necessary for proper MacOS compilation
     -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=true # Added for pybind11
     )
 


### PR DESCRIPTION
Fixes https://github.com/browsermt/ssplit-cpp/issues/11

- Upgraded emsdk version to latest tag 3.1.8
- Fixed failures arising from configuring and building the internal pcre2 library
    - `CMAKE_CROSSCOMPILING_EMULATOR` contains semicolon `;` separated arguments in latest emsdk versions (see [this](https://github.com/emscripten-core/emscripten/blob/main/emcmake.py#L41)). Preventing list expansion on the arguments of this variable before adding it to `PCRE2_CONFIGURE_OPTIONS` by replacing `;` with `$<SEMICOLON>` as [per this](https://cmake.org/cmake/help/git-stage/manual/cmake-generator-expressions.7.html#genex:SEMICOLON)
